### PR TITLE
only apply linear filter to the overlapping part

### DIFF
--- a/project 2/Resource/src/blending.m
+++ b/project 2/Resource/src/blending.m
@@ -18,19 +18,23 @@ function images_out = blending(images_in, images_starting_x, images_starting_y, 
     images_out = images_out - 1;
   end;
   
-  for i = 1:m
-    for j = 1:n
-      for k = 1:3
-        images_out(i,j,k) = images_in{1,1,1,1}(i,j,k);
-      end
-    end
-  end
+%  for i = 1:m
+%    for j = 1:n
+%      for k = 1:3
+%        images_out(i,j,k) = images_in{1,1,1,1}(i,j,k);
+%      end
+%    end
+%  end
 
   %% linear
   if type == 1
-    for i = 2:size(images_in,4)
+    for i = 1:size(images_in,4)
       left_most_x  = images_starting_x(i);
-      right_most_x = images_starting_x(i-1) + n - 1;
+      if i == 1
+          right_most_x = 0;
+      else
+          right_most_x = images_starting_x(i-1) + n - 1;
+      end
       left_image_weight  = linspace(1,0,right_most_x-left_most_x+1);
       right_image_weight = linspace(0,1,right_most_x-left_most_x+1);
       for a = 1:n
@@ -38,17 +42,18 @@ function images_out = blending(images_in, images_starting_x, images_starting_y, 
           for c = 1:3
             global_x = images_starting_x(i) + a - 1;
             global_y = images_starting_y(i) + b - 1;
-            if (global_x) < right_most_x
+            if images_out(global_y,global_x,c) > 0 && images_in{1,1,1,i}(b,a,c) > 0
               images_out(global_y,global_x,c) ...
                 = images_out(global_y,global_x,c) * left_image_weight(global_x-left_most_x+1) ...
                 + images_in{1,1,1,i}(b,a,c) * right_image_weight(a);
-            else
+            elseif images_out(global_y,global_x,c) == 0 && images_in{1,1,1,i}(b,a,c) > 0
               images_out(global_y, global_x,c) = images_in{1,1,1,i}(b,a,c);
             end
           end
         end
       end
     end
+
   
   %% else
   elseif type == 2

--- a/project 2/Resource/src/blending.m
+++ b/project 2/Resource/src/blending.m
@@ -46,7 +46,7 @@ function images_out = blending(images_in, images_starting_x, images_starting_y, 
               images_out(global_y,global_x,c) ...
                 = images_out(global_y,global_x,c) * left_image_weight(global_x-left_most_x+1) ...
                 + images_in{1,1,1,i}(b,a,c) * right_image_weight(a);
-            elseif images_out(global_y,global_x,c) == 0 && images_in{1,1,1,i}(b,a,c) > 0
+            elseif images_out(global_y,global_x,c) <= 0 && images_in{1,1,1,i}(b,a,c) > 0
               images_out(global_y, global_x,c) = images_in{1,1,1,i}(b,a,c);
             end
           end


### PR DESCRIPTION
The overlapping part might be irregular shape
In the blending part, the first image, which is the output of the image_matching.m, is not always start from (1, 1). Instead, it should be like other images use the starting_x and starting_y.